### PR TITLE
fix: TLS 无法后续处理请求

### DIFF
--- a/pkg/emulation/session/distributor.go
+++ b/pkg/emulation/session/distributor.go
@@ -94,19 +94,19 @@ func MagicDistributor(conn net.Conn, session *types.Session) bool {
 
 		session.IsTls = true
 		session.SetOutBuffer(new(bytes.Buffer)) // 重置buffer 不记录tls原始数据
-		conn2 = utils.NewLoggedConn(
-			tlsServer.Conn,
-			tlsServer.Conn,
-			session.GetOutBuffer(),
-			config.GetLimitSize(),
-		)
 		// 重新读取magicByte 长度 10
 		magicByte = make([]byte, 10)
-		n, err = conn2.Read(magicByte)
+		n, err = tlsServer.Conn.Read(magicByte)
 		if err != nil {
 			io.ReadAll(conn2) //出错继续读取
 			return false
 		}
+		conn2 = utils.NewLoggedConn(
+			tlsServer.Conn,
+			io.MultiReader(bytes.NewReader(magicByte[0:n]), tlsServer.Conn),
+			session.GetOutBuffer(),
+			config.GetLimitSize(),
+		)
 	}
 	/* gmTLS */
 	/*deleted*/


### PR DESCRIPTION
原 105 行取了 magicByte 没放回去，导致后续处理不了

例如 `curl -vk https://honeypot` 会失败，解析请求头失败导致返回 `400 Bad Request`，同时现象还有 http_session 表中 method 等数据全空

```
> GET / HTTP/1.1
> Host: 127.0.0.1:12345
> User-Agent: curl/8.11.0
> Accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Request completely sent off
< HTTP/1.1 400 Bad Request
< Date: Wed, 08 Jan 2025 15:54:04 GMT
< Content-Type: text/plain; charset=utf-8
< Content-Length: 26
< Connection: close
<
* shutting down connection #0
* TLSv1.3 (OUT), TLS alert, close notify (256):
Error when parsing request
```